### PR TITLE
added missing path to api docs generation

### DIFF
--- a/_scripts/api-reference-local.sh
+++ b/_scripts/api-reference-local.sh
@@ -14,7 +14,7 @@ echo -e "\n > importing data files for tinymce api reference: local from $1\n"
 
 rm -rf "$API_TMPDIR"
 mkdir "$API_TMPDIR"
-moxiedoc "$1/src/core/main/ts" -t tinymcenext -o "$API_TMPDIR/tinymce-api-reference.zip"
+moxiedoc "$1/src/core/main/ts" "$1/src/ui/main/ts" -t tinymcenext -o "$API_TMPDIR/tinymce-api-reference.zip"
 unzip -o "$API_TMPDIR/tinymce-api-reference.zip"
 rm _data/nav_api.json
 

--- a/_scripts/api-reference.sh
+++ b/_scripts/api-reference.sh
@@ -12,7 +12,7 @@ echo -e "\n > importing data files for tinymce api reference: $API_VERSION\n"
 #rm -rf "$API_TMPDIR"
 mkdir "$API_TMPDIR"
 curl -s "$TARBALL_URL" | tar xzf - -C "$API_TMPDIR" --strip-components 1
-moxiedoc "$API_TMPDIR/src/core/main/ts" -t tinymcenext -o "$API_TMPDIR/tinymce-api-reference.zip"
+moxiedoc "$API_TMPDIR/src/core/main/ts" "$API_TMPDIR/src/ui/main/ts" -t tinymcenext -o "$API_TMPDIR/tinymce-api-reference.zip"
 unzip -o "$API_TMPDIR/tinymce-api-reference.zip"
 
 echo ""


### PR DESCRIPTION
This adds back the ui part to the api docs. We restructured the tinymce project a while back to have the ui separate from the core so docs generation wasn't updated when we did that change. The 5.x doesn't even have that directory so there is no need to forward patch this to 5.x.