### PR TITLE
hotfix/WEBSITE-1358 - Implement better sitemaps

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,4 +9,5 @@ group :development, :test do
   gem 'jekyll-sitemap', '~> 1.2.0'
   gem 'redcarpet', '~> 3.4.0'
   gem 'nokogiri', '~> 1.8.2'
+  gem "jekyll-last-modified-at", "~> 1.0"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -27,6 +27,9 @@ GEM
       pathutil (~> 0.9)
       rouge (>= 1.7, < 4)
       safe_yaml (~> 1.0)
+    jekyll-last-modified-at (1.0.1)
+      jekyll (~> 3.3)
+      posix-spawn (~> 0.3.9)
     jekyll-redirect-from (0.13.0)
       jekyll (~> 3.3)
     jekyll-sass-converter (1.5.2)
@@ -47,6 +50,7 @@ GEM
       mini_portile2 (~> 2.3.0)
     pathutil (0.16.1)
       forwardable-extended (~> 2.6)
+    posix-spawn (0.3.13)
     public_suffix (3.0.2)
     rb-fsevent (0.10.3)
     rb-inotify (0.9.10)
@@ -66,10 +70,11 @@ PLATFORMS
 
 DEPENDENCIES
   jekyll (~> 3.8.3)
+  jekyll-last-modified-at (~> 1.0)
   jekyll-redirect-from (~> 0.13.0)
   jekyll-sitemap (~> 1.2.0)
   nokogiri (~> 1.8.2)
   redcarpet (~> 3.4.0)
 
 BUNDLED WITH
-   1.16.2
+   1.17.3

--- a/_config-local.sample.yml
+++ b/_config-local.sample.yml
@@ -1,3 +1,6 @@
-shared_baseurl: "https://www.tinymce.com"
+url: "https://www.tiny.cloud"
+shared_baseurl: "https://www.tiny.cloud"
 plugins:
+  - jekyll-last-modified-at
   - jekyll-redirect-from
+  - jekyll-sitemap

--- a/_config.yml
+++ b/_config.yml
@@ -1,5 +1,6 @@
+url: "https://www.tiny.cloud"
 permalink: pretty
-origin: "https://www.tinymce.com"
+origin: "https://www.tiny.cloud"
 baseurl: ""
 shared_baseurl: ""
 syntax_highlight_theme: "tomorrow-night"
@@ -27,5 +28,6 @@ redcarpet:
     - prettify
 
 plugins:
+  - jekyll-last-modified-at
   - jekyll-redirect-from
   - jekyll-sitemap

--- a/robots.txt
+++ b/robots.txt
@@ -1,0 +1,1 @@
+# Ignore this file; stops addition of robots.txt from sitemap generator.


### PR DESCRIPTION
- Changed URL, Origin properties from https://www.tinymce.com to correct URLs.
- Added jekyll-sitemap to local build for sitemap preview.
- Added last-modified-at for usage with sitemap.
- Added robots.txt to stop automatic robots.txt creation.

See PR https://github.com/tinymce/tinymce-docs-4x/pull/38 for more details.