### PR TITLE
WEBSITE-1694 - Launcher v4 docs failing to load CSS/image/JS files

### DIFF
--- a/_includes/template/bodycontents.html
+++ b/_includes/template/bodycontents.html
@@ -212,8 +212,8 @@
 </div>
 
 {% include_remote {{ site.origin }}/_docs/footer.html css="body > *" %}
-<script src="{{ site.shared_baseurl }}/scripts/common.min.js"></script>
-<script src="{{ site.shared_baseurl }}/scripts/docs.min.js"></script>
+<script src="{{ site.shared_baseurl }}{{ site.baseurl }}/scripts/common.min.js"></script>
+<script src="{{ site.shared_baseurl }}{{ site.baseurl }}/scripts/docs.min.js"></script>
 
 <script>
     {% include js/my-account-button.js %}

--- a/_includes/template/head.html
+++ b/_includes/template/head.html
@@ -13,8 +13,8 @@
     <title>TinyMCE | {{ page.meta_title | or:page.title }}</title>
 
     <link href="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.css" rel="stylesheet"/>
-    <link href="{{ site.shared_baseurl }}/css/common.min.css" rel="stylesheet">
-    <link href="{{ site.shared_baseurl }}/css/docs.min.css" rel="stylesheet">
+    <link href="{{ site.shared_baseurl }}{{ site.baseurl }}/css/common.min.css" rel="stylesheet">
+    <link href="{{ site.shared_baseurl }}{{ site.baseurl }}/css/docs.min.css" rel="stylesheet">
     <link href="//fast.fonts.net/cssapi/5d4ae438-4aca-4c75-8249-d9486d12b12e.css" rel="stylesheet">
 
     {% include_remote {{ site.origin }}/_docs/head.html css="head > *" %}


### PR DESCRIPTION
Fixed CSS/JS loads in `_includes` directory missing required `/docs` slug when running in branch/staging/prod deploys.