### PR TITLE
TINY-6231: Added changelog for 4.9.11 release

### DIFF
--- a/_data/nav.yml
+++ b/_data/nav.yml
@@ -493,6 +493,7 @@
 
 - url: "changelog"
   pages:
+  - url: "#Version 4.9.11 July 13, 2020"
   - url: "#Version 4.9.10 April 23, 2020"
   - url: "#Version 4.9.9 March 25, 2020"
   - url: "#Version 4.9.8 January 28, 2020"

--- a/changelog.md
+++ b/changelog.md
@@ -8,6 +8,11 @@ class: changelog
 
 {% capture changelog %}
 
+## Version 4.9.11 July 13, 2020
+* Fixed the `selection.setContent()` API not running parser filters.
+* Fixed content in an iframe element parsing as DOM elements instead of text content.
+* Fixed up and down keyboard navigation not working for inline `contenteditable="false"` elements.
+
 ## Version 4.9.10 April 23, 2020
 * Fixed an issue where the editor selection could end up inside a short ended element (eg br).
 * Fixed a security issue related to CDATA sanitization during parsing.


### PR DESCRIPTION
Related Ticket: TINY-6231

Description of Changes:
* Adds the changelog for the TinyMCE 4.9.11 release

DOD:
- [x] nav.yml has been updated if applicable
- [x] file has been included where required if applicable
- [x] files removed have been deleted, not just excluded from the build if applicable

Review
- [x] Documentation Team Lead has reviewed
- [x] Product Manager has reviewed
