### PR TITLE
Updated the API docs to pull from download.tiny.cloud instead of GitHub

### DIFF
--- a/_scripts/api-reference.sh
+++ b/_scripts/api-reference.sh
@@ -3,16 +3,19 @@
 set -e
 
 API_VERSION="$(cat .api-version)"
-TARBALL_URL="https://codeload.github.com/tinymce/tinymce/tar.gz/$API_VERSION"
+TARBALL_URL="http://download.tiny.cloud/tinymce/community/tinymce_${API_VERSION}_dev.zip"
 API_TMPDIR="/tmp/tinymce-$API_VERSION"
+API_TMPZIP="$API_TMPDIR/tinymce-$API_VERSION.zip"
 
 echo -e "\n > importing data files for tinymce api reference: $API_VERSION\n"
 
 #rm -f _data/nav_api.json
 #rm -rf "$API_TMPDIR"
 mkdir "$API_TMPDIR"
-curl -s "$TARBALL_URL" | tar xzf - -C "$API_TMPDIR" --strip-components 1
-moxiedoc "$API_TMPDIR/src/core/main/ts" "$API_TMPDIR/src/ui/main/ts" -t tinymcenext -o "$API_TMPDIR/tinymce-api-reference.zip"
+curl -sL "$TARBALL_URL" -o "$API_TMPZIP"
+unzip "$API_TMPZIP" -d "$API_TMPDIR"
+rm "$API_TMPZIP"
+moxiedoc "$API_TMPDIR/tinymce/src/core/main/ts" "$API_TMPDIR/tinymce/src/ui/main/ts" -t tinymcenext -o "$API_TMPDIR/tinymce-api-reference.zip"
 unzip -o "$API_TMPDIR/tinymce-api-reference.zip"
 
 echo ""


### PR DESCRIPTION
Related Ticket: TINY-6231

Description of Changes:
* The GitHub download system is currently down, so this updates the process to pull from download.tiny.cloud instead

DOD:
- [x] nav.yml has been updated if applicable
- [x] file has been included where required if applicable
- [x] files removed have been deleted, not just excluded from the build if applicable

Review
- [x] Documentation Team Lead has reviewed
- [ ] Product Manager has reviewed
