### PR TITLE
WSRF-244: Docs performance tweaks (updated)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ _data/nav_api.*
 _site
 _config-prod.yml
 _config-local.yml
+_config-environment.yml
 node_modules
 api
 vendor

--- a/_includes/template/bodycontents.html
+++ b/_includes/template/bodycontents.html
@@ -211,7 +211,7 @@
 
 </div>
 
-{% include_remote {{ site.origin }}/_docs/footer.html css="body > *" %}
+{% include_remote {{ site.origin }}/_docs/footer.html %}
 <script src="{{ site.shared_baseurl }}{{ site.baseurl }}/scripts/common.min.js"></script>
 <script src="{{ site.shared_baseurl }}{{ site.baseurl }}/scripts/docs.min.js"></script>
 

--- a/_includes/template/head.html
+++ b/_includes/template/head.html
@@ -12,12 +12,12 @@
 
     <title>TinyMCE | {{ page.meta_title | or:page.title }}</title>
 
-    <link href="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.css" rel="stylesheet"/>
+    <link href="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.css" rel="stylesheet" media="print" onload="this.media='all'; this.onload=null;" />
     <link href="{{ site.shared_baseurl }}{{ site.baseurl }}/css/common.min.css" rel="stylesheet">
     <link href="{{ site.shared_baseurl }}{{ site.baseurl }}/css/docs.min.css" rel="stylesheet">
     <link href="//fast.fonts.net/cssapi/5d4ae438-4aca-4c75-8249-d9486d12b12e.css" rel="stylesheet">
 
-    {% include_remote {{ site.origin }}/_docs/head.html css="head > *" %}
+    {% include_remote {{ site.origin }}/_docs/head.html %}
 
     {% assign tinymce_script_tag_included = false %}
 

--- a/_scripts/build.sh
+++ b/_scripts/build.sh
@@ -2,12 +2,30 @@
 
 set -e
 
-BASEURL="$(_scripts/get-baseurl.sh)"
+BASE_URL="$(_scripts/get-baseurl.sh)"
+STAGING_ORIGIN="https://www.staging.tiny.cloud"
 
-echo -e "\n > setting baseurl to: $BASEURL"
-echo "baseurl: \"$BASEURL\"" > _config-prod.yml
+echo -e "\n > setting base url to: $BASE_URL"
+echo "baseurl: \"$BASE_URL\"" > _config-environment.yml
 
-echo -e " > builidng documentation\n"
-bundle exec jekyll build --config _config.yml,_config-prod.yml
+#
+# Due to how the workflow for docs builds runs in Wercker, we have
+# to check specifically for the develop branch to override the
+# origin -- we need to do this for the template imports on the
+# head, footer and newsletter parts of the docs.
+#
+if [[ -z "${WERCKER_GIT_BRANCH}" ]]; then
+  echo -e " > local build - using default origin in config.yml"
+else
+  if [[ $WERCKER_GIT_BRANCH = "develop" ]]; then
+    echo -e " > staging build - setting origin to: $STAGING_ORIGIN"
+    echo "origin: \"$STAGING_ORIGIN\"" >> _config-environment.yml
+  else
+    echo -e " > production/feature branch build - using default origin in config.yml"
+  fi
+fi
+
+echo -e " > building documentation\n"
+bundle exec jekyll build --config _config.yml,_config-environment.yml
 
 echo ""


### PR DESCRIPTION
### Related Ticket:
[WSRF-244](https://ephocks.atlassian.net/browse/WSRF-244)

### Description of Changes:

* Replicated contents of PR #106

- Removed Avenir font load from fonts.net in favor of locally hosted files
- Defer the loading of the third-party docsearch.min.css
- Remove the link to the docs.min.css since it’s contents are now inlined in the _docs/head.html partial
- Update build script to account for the staging env

### DOD:
- [N/A] nav.yml has been updated if applicable
- [N/A] file has been included where required if applicable
- [N/A] files removed have been deleted, not just excluded from the build if applicable

### Review
- [x] Documentation Team Lead has reviewed
- [x] Product Manager has reviewed
