### PR TITLE
WSRF-244 - Incorrect location for font load

### DIFF
--- a/_includes/template/head.html
+++ b/_includes/template/head.html
@@ -14,8 +14,6 @@
 
     <link href="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.css" rel="stylesheet" media="print" onload="this.media='all'; this.onload=null;" />
     <link href="{{ site.shared_baseurl }}{{ site.baseurl }}/css/common.min.css" rel="stylesheet">
-    <link href="{{ site.shared_baseurl }}{{ site.baseurl }}/css/docs.min.css" rel="stylesheet">
-    <link href="//fast.fonts.net/cssapi/5d4ae438-4aca-4c75-8249-d9486d12b12e.css" rel="stylesheet">
 
     {% include_remote {{ site.origin }}/_docs/head.html %}
 


### PR DESCRIPTION
### Related Ticket: 
WSRF-244

### Description of Changes:
* docs.min.css is inlined into the head.html retrieved from docs, as are the font loads. Neither of the files in _includes/head.html are required any more.
* Removed unnecessary CSS from head.
* Removed unnecessary font load from head.

### DOD:
- [N/A] nav.yml has been updated if applicable
- [N/A] file has been included where required if applicable
- [N/A] files removed have been deleted, not just excluded from the build if applicable

### Review
- [x] Documentation Team Lead has reviewed
- [x] Product Manager has reviewed
